### PR TITLE
fix: typo in conky desktop filename

### DIFF
--- a/kaisen-documentation/kaisen-conky.html
+++ b/kaisen-documentation/kaisen-conky.html
@@ -156,7 +156,7 @@ Documentation
   </a>
   Disable conky launch
 </h3>
-<p>You cannot therefore remove the conky-all package, otherwise you risk removing your entire GUI.<br/>But do not panic ! You have a very easy way to not start conky even if it is installed.<br/>You must go and modify the file: <code class="inline">/etc/xdg/autostart/conky.desktop</code>.  </p><p>This file contains this by default:</p><pre><code class="makeup bash" translate="no"><span class="">[Desktop Entry]
+<p>You cannot therefore remove the conky-all package, otherwise you risk removing your entire GUI.<br/>But do not panic ! You have a very easy way to not start conky even if it is installed.<br/>You must go and modify the file: <code class="inline">/etc/xdg/autostart/kaisen-conky.desktop</code>.  </p><p>This file contains this by default:</p><pre><code class="makeup bash" translate="no"><span class="">[Desktop Entry]
 </span><span class="">Name=Kaisen Linux Conky
 </span><span class="">Exec=/usr/bin/conky
 </span><span class="">Hidden=false


### PR DESCRIPTION
Hi :wave: 

Well done for a great linux distribution ! I'm a big fan !

The filename of conky desktop file is wrong in the **Disable conky launch** section.

| Current filename | Correct filename | 
| ------------------------ | ------------------------ |
| conky.desktop | kaisen-conky.desktop |
